### PR TITLE
Remove info about applying to speak. Rearrange content.

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
     <p>The first <span class="sffz">SFFZ Talk About Things Conference</span> will take place on November 5th, 2017 at <a href="https://www.evanstongames.com/">Evanston Games and Cafe</a> from 1-3pm. Please do our host a solid and buy a sandwich or some coffee while you’re there. <b>Be sure to <a href="https://www.eventbrite.com/e/sffz-talk-about-things-conference-tickets-36909638723">RSVP on Eventbrite</a>!</b></p>
     <p>No need to buy a ticket, we just need to know how many chairs to put out and how much space we'll need. There's no cost to attend, but donations towards space rental are super appreciated on the day of the event. We can’t wait to see you!</p>
     <div class="divider"></div>
-    <p>This first event is a lightning talk showcase of cool things people are learning about or involved in. Talks are 5-15 minutes along and assume no prior knowledge of the topic. We've selected our talks for this first event, and we'll be announcing them soon!</p>
+    <p>This first event is a lightning talk showcase of cool things people are learning about or involved in. Talks are 5-15 minutes long and assume no prior knowledge of the topic. We've selected our talks for this first event, and we'll be announcing them soon!</p>
     <p>Don't want to present, and just want to attend and soak up all that awesome knowledge? That's fine, too! We encourage you to take notes, livetweet, and ask awesome questions of our speakers afterwards.</p>
     <p>Please note that <span>SFFZ</span> has a code of conduct for all events and online spaces. <b>Make sure to check it out <a href="https://github.com/super-fun-friends-zone/super-fun-friends-zone.github.io/blob/master/event_code_of_conduct.md">on github</a></b>.
     <div class="divider"></div>

--- a/index.html
+++ b/index.html
@@ -19,25 +19,12 @@
       <h3><span class="sffz">SFFZ</span> is a collaborative learning zone and we want YOU to participate!</h3>
     </div>
     <div class="divider"></div>
-    <p>Our first event will be a lightning talk showcase of cool things people are learning about or involved in. Talks should last about 10 minutes, and can be about anything you find interesting. Talks should assume that your audience has no prior knowledge of your topic, but should still aim to be engaging for people familiar with your material.</p>
-    <p>Don't want to present, and just want to attend and soak up all that awesome knowledge? That's fine, too! We encourage you to take notes, livetweet, and ask awesome questions of our speakers afterwards.</p>
-    <p>Please note that <span>SFFZ</span> has a code of conduct for all events and online spaces. <b>Make sure to check it out <a href="https://github.com/super-fun-friends-zone/super-fun-friends-zone.github.io/blob/master/event_code_of_conduct.md">on github</a></b>.
-    <div class="divider"></div>
     <p>The first <span class="sffz">SFFZ Talk About Things Conference</span> will take place on November 5th, 2017 at <a href="https://www.evanstongames.com/">Evanston Games and Cafe</a> from 1-3pm. Please do our host a solid and buy a sandwich or some coffee while you’re there. <b>Be sure to <a href="https://www.eventbrite.com/e/sffz-talk-about-things-conference-tickets-36909638723">RSVP on Eventbrite</a>!</b></p>
     <p>No need to buy a ticket, we just need to know how many chairs to put out and how much space we'll need. There's no cost to attend, but donations towards space rental are super appreciated on the day of the event. We can’t wait to see you!</p>
     <div class="divider"></div>
-    Apply to speak at <span class="sffz">SFFZ Talk about Things Conference</span> <a href="https://docs.google.com/forms/d/1Jj0KX9j_CISW5VckSC4gB7zNAyNVYhdZGHGaeYpiVEs/viewform">HERE</a>!
-    <div class="divider"></div>
-    <p>If you’re not sure what to talk about, here are some categories that we think sound fascinating:</p>
-    <ul>
-      <li>Gaming and interactive storytelling media</li>
-      <li>Science and technology</li>
-      <li>Making and crafting</li>
-      <li>Art, music, and culture</li>
-      <li>Anything else you find interesting!</li>
-    </ul>
-    <p>Slide decks for talks are encouraged but not required. We will provide projectors for speakers and make slides and presenter notes available online after the event.</p>
-    <p>If you’d like to reminders about proposal deadlines and announcements for upcoming events, you should sign up for our newsletter below!</p>
+    <p>This first event is a lightning talk showcase of cool things people are learning about or involved in. Talks are 5-15 minutes along and assume no prior knowledge of the topic. We've selected our talks for this first event, and we'll be announcing them soon!</p>
+    <p>Don't want to present, and just want to attend and soak up all that awesome knowledge? That's fine, too! We encourage you to take notes, livetweet, and ask awesome questions of our speakers afterwards.</p>
+    <p>Please note that <span>SFFZ</span> has a code of conduct for all events and online spaces. <b>Make sure to check it out <a href="https://github.com/super-fun-friends-zone/super-fun-friends-zone.github.io/blob/master/event_code_of_conduct.md">on github</a></b>.
     <div class="divider"></div>
     <div class="outro">
     <h3>Get the latest <span class="sffz">SFFZ</span> updates, subsribe to our newsletter!</h3>


### PR DESCRIPTION
I removed the info about how to apply to speak and rearranged the content. It includes a line about speakers being announced soon. Figured we should do an update like this quick in case anyone is checking.